### PR TITLE
General fixes for use in a workflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+before_install:
+  - npm update -g npm
 language: node_js
 node_js:
   - '0.10'

--- a/bin/chg
+++ b/bin/chg
@@ -7,28 +7,28 @@ var commands = require('../lib/commands.js');
 var program = require('commander');
 var prompt = require('prompt');
 
-function callback(err, success){
-  if (err) {
-    return console.log('ERROR: '+err);
-  } else if (success) {
-    console.log(success);
-  }
-}
-
 program.version(pkg.version);
 
 program
   .command('init')
   .description('Create the CHANGELOG.md in the current directory')
   .action(function(args){
-    commands.init({}, callback);
+    commands.init({}, function(err, changeLogFile) {
+      if (err) return console.error(err.message);
+
+      console.log(changeLogFile +' created');
+    });
   });
 
 program
   .command('add [line]')
   .description('Add one line to the changelog')
   .action(function(line, info){
-    commands.add(line, {}, callback);
+    commands.add(line, {}, function(err, line) {
+      if (err) return console.error(err.message);
+
+      console.log('Change added: '+ line);
+    });
   });
 
 program
@@ -42,14 +42,22 @@ program
       options.date = info.date;
     }
 
-    commands.release(version, options, callback);
+    commands.release(version, options, function(err, changes) {
+      if (err) return console.error(err.message);
+
+      console.log('Changelog updated with new release: '+ changes.title);
+    });
   });
 
 program
   .command('delete')
   .description('Delete the changelog')
   .action(function(info){
-    commands.delete({}, callback);
+    commands.delete({}, function(err, changeLogFile) {
+      if (err) return console.error(err.message);
+
+      console.log(changeLogFile +' deleted.');
+    });
   });
 
 program.parse(process.argv);

--- a/lib/chg.js
+++ b/lib/chg.js
@@ -111,7 +111,7 @@ chg.add = function(line, options, callback){
 
 /**
 * Creates a new release by bumping the version, moving everything in the unreleased head to a new section headed by the new version (and creating a new, empty head)
-* @param {string} version - what kind of release this is, either 'major', 'minor', or 'patch'
+* @param {string} version - the new release (this will be the title for the changelog)
 * @param {object} options
 * @param {string} options.date - date of the new release (defaults to the current date)
 * @param {string} options.version - release type to create (if version param is null)
@@ -127,16 +127,6 @@ chg.release = function(version, options, callback){
 
   if (!version) {
     return callback(new Error('Version required'));
-  }
-
-  // allow incrementing version for a release type
-  if (['major','minor','patch'].indexOf(version) !== -1) {
-    if (fs.existsSync('./package.json')) {
-      pkgVersion = require(process.cwd()+'/package.json').version;
-      version = semver.inc(pkgVersion, version);
-    } else {
-      callback(new Error('No package.json was found'));
-    }
   }
 
   // get existing contents

--- a/lib/chg.js
+++ b/lib/chg.js
@@ -31,6 +31,18 @@ function getChangeLog(){
   return fs.readFileSync(changeLogFile, 'utf8');
 }
 
+/**
+* Callbacks are standard "node style"
+* @callback chgCallback
+* @param {object} Error
+* @param {string} responseMessage
+*/
+
+/**
+* Creates CHANGELOG.md if it does not exist.
+* @param {object} options
+* @param {chgCallback} callback - successfull returns the new changelog file.
+*/
 chg.init = function(options, callback){
   options = options || {};
   callback = callback || defCallback;
@@ -47,19 +59,29 @@ chg.init = function(options, callback){
   callback(null, changeLogFile);
 };
 
-
+/**
+* Deletes CHANGELOG.md
+* @param {object} options
+* @param {chgCallback} callback - success returns the deleted changelog file.
+*/
 chg.delete = function(options, callback){
   options = options || {};
   callback = callback || defCallback;
 
-  if (fs.existsSync(changeLogFile)){
-    shell.rm(changeLogFile);
-    callback(null, changeLogFile);
-  } else {
-    callback(new Error(changeLogFile+' does not exist'));
+  if (!fs.existsSync(changeLogFile)) {
+    return callback(new Error(changeLogFile+' does not exist'));
   }
+
+  shell.rm(changeLogFile);
+  callback(null, changeLogFile);
 };
 
+/**
+* Add a new line to CHANGELOG.md
+* @param {string} line - the new line to be added
+* @param {object} options
+* @param {chgCallback} callback - success returns the newly added line
+*/
 chg.add = function(line, options, callback){
   var contents, sections, top;
 
@@ -87,6 +109,14 @@ chg.add = function(line, options, callback){
   callback(null, line);
 };
 
+/**
+* Creates a new release by bumping the version, moving everything in the unreleased head to a new section headed by the new version (and creating a new, empty head)
+* @param {string} version - what kind of release this is, either 'major', 'minor', or 'patch'
+* @param {object} options
+* @param {string} options.date - date of the new release (defaults to the current date)
+* @param {string} options.version - release type to create (if version param is null)
+* @param {chgCallback} callback - success returns the newly added line
+*/
 chg.release = function(version, options, callback){
   var date, contents, changes, title, pkgVersion;
 
@@ -95,9 +125,7 @@ chg.release = function(version, options, callback){
   date = options.date || moment().format('YYYY-MM-DD');
   version = version || options.version || null;
 
-  if (!version) {
-    return callback('Version required');
-  }
+  if (!version) return callback(new Error('Version required'));
 
   // allow incrementing version for a release type
   if (['major','minor','patch'].indexOf(version) !== -1) {

--- a/lib/chg.js
+++ b/lib/chg.js
@@ -13,7 +13,6 @@ var chg = module.exports = {};
 var fs = require('fs');
 var shell = require('shelljs');
 var moment = require('moment');
-var semver = require('semver');
 
 var changeLogFile = 'CHANGELOG.md';
 var unreleasedTitle = '## HEAD (Unreleased)\n';
@@ -118,7 +117,7 @@ chg.add = function(line, options, callback){
 * @param {chgCallback} callback - success returns the newly added line
 */
 chg.release = function(version, options, callback){
-  var date, contents, changes, title, pkgVersion;
+  var date, contents, changes, title;
 
   callback = callback || defCallback;
   options = options || {};
@@ -150,5 +149,4 @@ chg.release = function(version, options, callback){
   fs.writeFileSync(changeLogFile, contents, 'utf8');
 
   callback(null, { title: title, changes: changes, changelog: contents });
-  return changes;
 };

--- a/lib/chg.js
+++ b/lib/chg.js
@@ -36,7 +36,7 @@ chg.init = function(options, callback){
   callback = callback || defCallback;
 
   if (fs.existsSync(changeLogFile)){
-    return callback(changeLogFile + ' already exists');
+    return callback(new Error(changeLogFile + ' already exists'));
   }
 
   var contents = 'CHANGELOG\n=========\n\n';
@@ -44,8 +44,9 @@ chg.init = function(options, callback){
 
   fs.writeFileSync(changeLogFile, contents, 'utf8');
 
-  callback(null, changeLogFile+' created');
+  callback(null, changeLogFile);
 };
+
 
 chg.delete = function(options, callback){
   options = options || {};
@@ -53,9 +54,9 @@ chg.delete = function(options, callback){
 
   if (fs.existsSync(changeLogFile)){
     shell.rm(changeLogFile);
-    callback(null, changeLogFile+' deleted');
+    callback(null, changeLogFile);
   } else {
-    callback(changeLogFile+' does not exist');
+    callback(new Error(changeLogFile+' does not exist'));
   }
 };
 
@@ -67,8 +68,8 @@ chg.add = function(line, options, callback){
 
   // get existing contents
   contents = getChangeLog();
-  if (!contents) { 
-    return callback(ERR_NO_CHANGELOG);
+  if (!contents) {
+    return callback(new Error(ERR_NO_CHANGELOG));
   }
 
   // if 'noItems' is there, remove it
@@ -83,7 +84,7 @@ chg.add = function(line, options, callback){
   contents = top + divider + sections[1];
   fs.writeFileSync(changeLogFile, contents, 'utf8');
 
-  callback(null, 'Change added');
+  callback(null, line);
 };
 
 chg.release = function(version, options, callback){
@@ -94,8 +95,8 @@ chg.release = function(version, options, callback){
   date = options.date || moment().format('YYYY-MM-DD');
   version = version || options.version || null;
 
-  if (!version) { 
-    return callback('Version required'); 
+  if (!version) {
+    return callback('Version required');
   }
 
   // allow incrementing version for a release type
@@ -104,14 +105,14 @@ chg.release = function(version, options, callback){
       pkgVersion = require(process.cwd()+'/package.json').version;
       version = semver.inc(pkgVersion, version);
     } else {
-      callback('No package.json was found');
+      callback(new Error('No package.json was found'));
     }
   }
 
   // get existing contents
   contents = getChangeLog();
-  if (!contents) { 
-    return callback(ERR_NO_CHANGELOG);
+  if (!contents) {
+    return callback(new Error(ERR_NO_CHANGELOG));
   }
 
   // get everything after the unreleased title
@@ -128,5 +129,6 @@ chg.release = function(version, options, callback){
 
   fs.writeFileSync(changeLogFile, contents, 'utf8');
 
-  callback(null, 'Changelog updated with new release');
+  callback(null, { title: title, changes: changes, changelog: contents });
+  return changes;
 };

--- a/lib/chg.js
+++ b/lib/chg.js
@@ -125,7 +125,9 @@ chg.release = function(version, options, callback){
   date = options.date || moment().format('YYYY-MM-DD');
   version = version || options.version || null;
 
-  if (!version) return callback(new Error('Version required'));
+  if (!version) {
+    return callback(new Error('Version required'));
+  }
 
   // allow incrementing version for a release type
   if (['major','minor','patch'].indexOf(version) !== -1) {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "bin": {
     "chg": "./bin/chg"
   },
+  "main": "lib/chg.js",
   "devDependencies": {
     "grunt-cli": "~0.1.0",
     "grunt": "~0.4.0",

--- a/tasks/grunt-chg.js
+++ b/tasks/grunt-chg.js
@@ -42,6 +42,6 @@ module.exports = function(grunt) {
 
   grunt.registerTask('chg-delete', 'Delete the changelog', function() {
     var done =  this.async();
-    commands.release({}, getCallback(done));
+    commands.delete({}, getCallback(done));
   });
 };

--- a/tasks/grunt-chg.js
+++ b/tasks/grunt-chg.js
@@ -17,11 +17,11 @@ module.exports = function(grunt) {
   function getCallback(done) {
     return function(err, success){
       if (err) {
-        return grunt.log.error(err);
-      } else if (success) {
-        grunt.log.writeln(success);
-        done();
+        grunt.log.error(err.message);
+        return done(false);
       }
+      grunt.log.writeln(success);
+      done(true);
     }
   }
 
@@ -37,7 +37,15 @@ module.exports = function(grunt) {
 
   grunt.registerTask('chg-release', 'Add a new release and move unrleased changes under it', function(version) {
     var done =  this.async();
-    commands.release(version, {}, getCallback(done));
+    commands.release(version, {}, function(err, release) {
+      if (err) {
+        grunt.log.error(err.message);
+        done(false);
+      }
+
+      grunt.config.set('chg.release.title', release.title);
+      grunt.config.set('chg.release.changes', release.changes);
+    });
   });
 
   grunt.registerTask('chg-delete', 'Delete the changelog', function() {


### PR DESCRIPTION
- Error objects instead of strings
- Successful responses are (generally) useful information instead of success strings
- Fixed the `delete` grunt test
- Added a `main` key to the package.json to allow `chg` to be required and used programmatically
- In the grunt task, set the release return values to grunt configs so other grunt tasks could use them.
- Added some documentation comments.