### PR TITLE
Add synchronous returns

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ chg.add('My first change', {}, callback);
 
 // create a release
 chg.release('0.0.1', {}, callback);
+
+// each command can take a callback, but each also returns synchronously
+var changeData = chg.release('0.0.1', {});
+// changeData = { title: '0.0.1', changes: '* Removed crusty semantic html, javascript app ftw', changeLog: '/* entire changelog */' }
 ```
 
 ## Using as a grunt plugin

--- a/lib/chg.js
+++ b/lib/chg.js
@@ -48,7 +48,7 @@ chg.init = function(options, callback){
   callback = callback || noopCallback;
 
   if (fs.existsSync(changeLogFile)){
-    var err = new Error(changeLogFile + ' already exists')
+    var err = new Error(changeLogFile + ' already exists');
     callback(err);
     throw err;
   }
@@ -75,7 +75,7 @@ chg.delete = function(options, callback){
   callback = callback || noopCallback;
 
   if (!fs.existsSync(changeLogFile)) {
-    var err = new Error(changeLogFile+' does not exist')
+    var err = new Error(changeLogFile+' does not exist');
     callback(err);
     throw err;
   }
@@ -103,7 +103,7 @@ chg.add = function(line, options, callback){
   // get existing contents
   contents = getChangeLog();
   if (!contents) {
-    var err = new Error(ERR_NO_CHANGELOG)
+    var err = new Error(ERR_NO_CHANGELOG);
     callback(err);
     throw err;
   }
@@ -139,7 +139,7 @@ chg.add = function(line, options, callback){
 * @returns {object} changeData.changelog - entire changelog contents
 */
 chg.release = function(version, options, callback){
-  var date, contents, changes, title;
+  var date, contents, changes, title, err;
 
   callback = callback || noopCallback;
   options = options || {};
@@ -147,15 +147,15 @@ chg.release = function(version, options, callback){
   version = version || options.version || null;
 
   if (!version) {
-    var err = new Error('Version required')
-    return callback(err);
+    err = new Error('Version required');
+    callback(err);
     throw err;
   }
 
   // get existing contents
   contents = getChangeLog();
   if (!contents) {
-    var err = new Error(ERR_NO_CHANGELOG);
+    err = new Error(ERR_NO_CHANGELOG);
     callback(err);
     throw err;
   }

--- a/lib/chg.js
+++ b/lib/chg.js
@@ -21,7 +21,7 @@ var divider = '--------------------\n\n';
 
 var ERR_NO_CHANGELOG = changeLogFile+' does not exist. Change to the directory where it does exist, or run `init` to create one in the current directory.';
 
-function defCallback(){}
+function noopCallback(){}
 
 function getChangeLog(){
   if (!fs.existsSync(changeLogFile)) {
@@ -41,13 +41,16 @@ function getChangeLog(){
 * Creates CHANGELOG.md if it does not exist.
 * @param {object} options
 * @param {chgCallback} callback - successfull returns the new changelog file.
+* @returns {string} changelog filename
 */
 chg.init = function(options, callback){
   options = options || {};
-  callback = callback || defCallback;
+  callback = callback || noopCallback;
 
   if (fs.existsSync(changeLogFile)){
-    return callback(new Error(changeLogFile + ' already exists'));
+    var err = new Error(changeLogFile + ' already exists')
+    callback(err);
+    throw err;
   }
 
   var contents = 'CHANGELOG\n=========\n\n';
@@ -55,24 +58,33 @@ chg.init = function(options, callback){
 
   fs.writeFileSync(changeLogFile, contents, 'utf8');
 
+
   callback(null, changeLogFile);
+
+  return changeLogFile;
 };
 
 /**
 * Deletes CHANGELOG.md
 * @param {object} options
-* @param {chgCallback} callback - success returns the deleted changelog file.
+* @param {chgCallback} callback - success returns the deleted changelog file
+* @returns {string} changelog filename
 */
 chg.delete = function(options, callback){
   options = options || {};
-  callback = callback || defCallback;
+  callback = callback || noopCallback;
 
   if (!fs.existsSync(changeLogFile)) {
-    return callback(new Error(changeLogFile+' does not exist'));
+    var err = new Error(changeLogFile+' does not exist')
+    callback(err);
+    throw err;
   }
 
   shell.rm(changeLogFile);
+
   callback(null, changeLogFile);
+
+  return changeLogFile;
 };
 
 /**
@@ -80,17 +92,20 @@ chg.delete = function(options, callback){
 * @param {string} line - the new line to be added
 * @param {object} options
 * @param {chgCallback} callback - success returns the newly added line
+* @returns {string} the new line added
 */
 chg.add = function(line, options, callback){
   var contents, sections, top;
 
   options = options || {};
-  callback = callback || defCallback;
+  callback = callback || noopCallback;
 
   // get existing contents
   contents = getChangeLog();
   if (!contents) {
-    return callback(new Error(ERR_NO_CHANGELOG));
+    var err = new Error(ERR_NO_CHANGELOG)
+    callback(err);
+    throw err;
   }
 
   // if 'noItems' is there, remove it
@@ -105,7 +120,10 @@ chg.add = function(line, options, callback){
   contents = top + divider + sections[1];
   fs.writeFileSync(changeLogFile, contents, 'utf8');
 
+
   callback(null, line);
+
+  return line;
 };
 
 /**
@@ -114,24 +132,32 @@ chg.add = function(line, options, callback){
 * @param {object} options
 * @param {string} options.date - date of the new release (defaults to the current date)
 * @param {string} options.version - release type to create (if version param is null)
-* @param {chgCallback} callback - success returns the newly added line
+* @param {chgCallback} callback - success returns an object containing the new changes
+* @returns {object} changeData
+* @returns {object} changeData.title - new title to be created
+* @returns {object} changeData.changes - list of changes added under the new title
+* @returns {object} changeData.changelog - entire changelog contents
 */
 chg.release = function(version, options, callback){
   var date, contents, changes, title;
 
-  callback = callback || defCallback;
+  callback = callback || noopCallback;
   options = options || {};
   date = options.date || moment().format('YYYY-MM-DD');
   version = version || options.version || null;
 
   if (!version) {
-    return callback(new Error('Version required'));
+    var err = new Error('Version required')
+    return callback(err);
+    throw err;
   }
 
   // get existing contents
   contents = getChangeLog();
   if (!contents) {
-    return callback(new Error(ERR_NO_CHANGELOG));
+    var err = new Error(ERR_NO_CHANGELOG);
+    callback(err);
+    throw err;
   }
 
   // get everything after the unreleased title
@@ -148,5 +174,8 @@ chg.release = function(version, options, callback){
 
   fs.writeFileSync(changeLogFile, contents, 'utf8');
 
-  callback(null, { title: title, changes: changes, changelog: contents });
+  var changeData = { title: title, changes: changes, changelog: contents };
+  callback(null, changeData);
+
+  return changeData;
 };


### PR DESCRIPTION
All the `chg` methods are also synchronous, so might as well.

This is based off of #2, so that should be pulled in first.