### PR TITLE
Call done() when chg-release is done.

### DIFF
--- a/tasks/grunt-chg.js
+++ b/tasks/grunt-chg.js
@@ -45,6 +45,7 @@ module.exports = function(grunt) {
 
       grunt.config.set('chg.release.title', release.title);
       grunt.config.set('chg.release.changes', release.changes);
+      done();
     });
   });
 


### PR DESCRIPTION
Otherwise, this task will hang indefinitely.